### PR TITLE
Delete default value of runtimecontext in filter and trigger deploy dialog.

### DIFF
--- a/trigger-and-filter/components/deploy-filter-dialog/deploy-filter-dialog.component.ts
+++ b/trigger-and-filter/components/deploy-filter-dialog/deploy-filter-dialog.component.ts
@@ -44,7 +44,7 @@ export class DeployFilterDialogComponent extends XcDialogComponent<XoFilterInsta
     optional: boolean;
     busy: boolean;
 
-    context: XoRuntimeContext = this.injectedData.runtimeContext;
+    context: XoRuntimeContext;
     triggerInstance: string;
 
     runtimeContextDataWrapper: XcAutocompleteDataWrapper<XoRuntimeContext> = new XcAutocompleteDataWrapper<XoRuntimeContext>(
@@ -82,15 +82,19 @@ export class DeployFilterDialogComponent extends XcDialogComponent<XoFilterInsta
     }
 
     fillTriggerInstanceWrapper() {
-        this.apiService.startOrderAssertFlat<XoTriggerInstance>(FM_RTC, ORDER_TYPES.POSSIBLE_TRIGGER_INSTANCES, [this.injectedData, this.context], XoTriggerInstanceArray)
-            .subscribe({
-                next: result => {
-                    this.triggerInstanceDataWrapper.values = result.map(triggerInstance => XcOptionItemString(triggerInstance.triggerInstance));
-                },
-                error: err => {
-                    this.dialogService.error(err);
-                }
-            });
+        if (this.context) {
+            this.apiService.startOrderAssertFlat<XoTriggerInstance>(FM_RTC, ORDER_TYPES.POSSIBLE_TRIGGER_INSTANCES, [this.injectedData, this.context], XoTriggerInstanceArray)
+                .subscribe({
+                    next: result => {
+                        this.triggerInstanceDataWrapper.values = result.map(triggerInstance => XcOptionItemString(triggerInstance.triggerInstance));
+                    },
+                    error: err => {
+                        this.dialogService.error(err);
+                    }
+                });
+        } else {
+            this.triggerInstanceDataWrapper.values = [];
+        }
     }
 
     deploy() {

--- a/trigger-and-filter/components/deploy-trigger-dialog/deploy-trigger-dialog.component.ts
+++ b/trigger-and-filter/components/deploy-trigger-dialog/deploy-trigger-dialog.component.ts
@@ -51,7 +51,7 @@ export class DeployTriggerDialogComponent extends XcDialogComponent<XoTriggerIns
     legacy: boolean;
     startparameter: {parameter: StartParameter; wrapper: XcAutocompleteDataWrapper<string>}[] = [];
 
-    context: XoRuntimeContext = this.injectedData.runtimeContext;
+    context: XoRuntimeContext;
 
     runtimeContextDataWrapper: XcAutocompleteDataWrapper<XoRuntimeContext> = new XcAutocompleteDataWrapper<XoRuntimeContext>(
         () => this.context,

--- a/version.ts
+++ b/version.ts
@@ -16,4 +16,4 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  */
 export const FactoryManagerName = 'Factory Manager';
-export const FactoryManagerVersion = '1.5.5';
+export const FactoryManagerVersion = '1.5.6';


### PR DESCRIPTION
Request no possible trigger instances, if runtimecontext is empty.